### PR TITLE
Use openjdk7 instead of oraclejdk7 to build with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
-sudo: false
+dist: trusty
 language: java
+addons:
+  apt:
+    packages:
+      - openjdk-7-jdk
 jdk:
-  - oraclejdk7
+  - openjdk7
 install:
   - mvn install -DskipTests=true -B -V
 script:


### PR DESCRIPTION
https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038